### PR TITLE
ダウンロードURLの変更

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: wate
-  description: install "Unofficial" CLI client for the Sakura Cloud
+  description: install CLI client for the Sakura Cloud
   license: MIT
   min_ansible_version: 2.1
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 - block:
   - name: import gpg key
     rpm_key:
-      key: https://usacloud.b.sakurastorage.jp/repos/GPG-KEY-usacloud
+      key: https://releases.usacloud.jp/usacloud/repos/GPG-KEY-usacloud
   - name: add repository
     yum_repository:
       name: usacloud
       description: usacloud
-      baseurl: https://usacloud.b.sakurastorage.jp/repos/centos/$basearch
+      baseurl: https://releases.usacloud.jp/usacloud/repos/centos/$basearch
       gpgcheck: true
       file: usacloud
   - name: install usacloud
@@ -21,10 +21,10 @@
       name: apt-transport-https
   - name: import gpg key
     apt_key:
-      url: https://usacloud.b.sakurastorage.jp/repos/GPG-KEY-usacloud
+      url: https://releases.usacloud.jp/usacloud/repos/GPG-KEY-usacloud
   - name: add repository
     apt_repository:
-      repo: deb https://usacloud.b.sakurastorage.jp/repos/debian /
+      repo: deb https://releases.usacloud.jp/usacloud/repos/debian /
       filename: usacloud
   - name: install usacloud
     apt:


### PR DESCRIPTION
GPG-KEYやapt/yumでのリソースダウンロードURLが古いため最新のURLに更新しました。