### PR TITLE
1つ前のバージョンのテストを追加

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,12 +7,15 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 6
     - name: Debian
       versions:
         - stretch
+        - jessie
     - name: Ubuntu
       versions:
         - xenial
+        - trusty
   galaxy_tags: []
 
 dependencies: []

--- a/molecule.yml
+++ b/molecule.yml
@@ -5,12 +5,18 @@ driver:
   name: vagrant
 vagrant:
   platforms:
-    - name: centos
+    - name: centos7
       box: bento/centos-7
+    - name: centos6
+      box: bento/centos-6
     - name: xenial
       box: bento/ubuntu-16.04
+    - name: trusty
+      box: bento/ubuntu-14.04
     - name: stretch
       box: bento/debian-9
+    - name: jessie
+      box: bento/debian-8
   providers:
     - name: virtualbox
       type: virtualbox

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,18 @@
 require 'serverspec'
 require 'net/ssh'
 
-set :backend, :ssh
-
 host = ENV['TARGET_HOST']
 ssh_config_files = ['./.vagrant/ssh-config'] + Net::SSH::Config.default_files
 options = Net::SSH::Config.for(host, ssh_config_files)
+options[:user] ||= 'vagrant'
+options[:keys].push("#{Dir.home}/.vagrant.d/insecure_private_key")
 
-options[:user] ||= Etc.getlogin
-
-set :host,        options[:host_name] || host
+set :backend, :ssh
+set :host, host
 set :ssh_options, options
+
+RSpec.configure do |config|
+  config.color = true
+  config.tty = true
+  config.formatter = :documentation
+end


### PR DESCRIPTION
以下のバージョンでのテストの追加および動作確認

* CentOS 6
* Trusty(Ubuntu 14)
* Jessie(Debian 8)

上記に伴うAnsible Galaxyのメタ情報の更新