### PR TITLE
Add bionic test

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -9,10 +9,10 @@ vagrant:
       box: bento/centos-7
     - name: centos6
       box: bento/centos-6
+    - name: bionic
+      box: bento/ubuntu-18.04
     - name: xenial
       box: bento/ubuntu-16.04
-    - name: trusty
-      box: bento/ubuntu-14.04
     - name: stretch
       box: bento/debian-9
     - name: jessie

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   - name: import gpg key
     rpm_key:
       key: https://releases.usacloud.jp/usacloud/repos/GPG-KEY-usacloud
+      validate_certs: "{{ true if ansible_python_version is version_compare('2.7.9', '>=') else false }}"
   - name: add repository
     yum_repository:
       name: usacloud


### PR DESCRIPTION
* 対応環境にbionicを追加
* 対応環境にtrustyを削除
* CentOS 6環境で利用する場合にrpm_keyモジュールでSSLの検証を行わないように修正
    * インストールされているPythonのバージョンが古く、SSLの検証でエラーが発生するため
